### PR TITLE
Apply policy for @atomist/sdm-core

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -291,9 +291,9 @@
       }
     },
     "@atomist/sdm-core": {
-      "version": "1.6.2-master.20190822002319",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.6.2-master.20190822002319.tgz",
-      "integrity": "sha512-CULaVsRrO4wn6mffhQ7tcPerJ4tDkkuKv8Ese/RK9Cj2di+mhcBcB+R53M/HWDb9pWQO/OFiV8HtkPA9/bEYZQ==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-core/-/sdm-core-1.6.1.tgz",
+      "integrity": "sha512-oVLnKkRVsrt4pMrs/N5+ixK9PxfkxXPRdjE34e0gkBWIOwGAlwBaH1zm07YrB919GSeXTZ/oeRuX/KfyBesmcw==",
       "requires": {
         "@kubernetes/client-node": "^0.10.2",
         "@octokit/rest": "^16.28.3",
@@ -304,13 +304,12 @@
         "app-root-path": "^2.2.1",
         "axios": "^0.19.0",
         "chalk": "^2.4.2",
-        "fast-json-stable-stringify": "^2.0.0",
         "fs-extra": "^8.1.0",
         "glob": "^7.1.4",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.14",
         "moment": "^2.24.0",
-        "moment-duration-format": "2.2.2",
+        "moment-duration-format": "2.3.2",
         "promise-retry": "^1.1.1",
         "proper-lockfile": "^4.1.1",
         "request": "^2.88.0",
@@ -8302,9 +8301,9 @@
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
     },
     "moment-duration-format": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.2.2.tgz",
-      "integrity": "sha1-uVdhLeJgFsmtnrYIfAVFc+USd3k="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
+      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ=="
     },
     "moment-timezone": {
       "version": "0.5.26",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@atomist/automation-client": "1.6.3-master.20190821065818",
     "@atomist/microgrammar": "^1.2.1",
     "@atomist/sdm": "1.6.2-master.20190821222758",
-    "@atomist/sdm-core": "1.6.2-master.20190822002319",
+    "@atomist/sdm-core": "^1.6.1",
     "@atomist/sdm-pack-aspect": "^1.0.0-master.20190828014024",
     "@atomist/sdm-pack-build": "^1.0.5",
     "@atomist/sdm-pack-clojure": "^2.0.1-master.20190826190616",


### PR DESCRIPTION
Apply policy `npm-project-deps::atomist::sdm-core`:

**New NPM Package Version Policy**
Policy version for NPM package *@atomist/sdm-core* is `^1.6.1`.
Project *atomist/org-visualizer/master* is currently using version `1.6.2-master.20190822002319`.

_NPM dependencies_
```@atomist/sdm-core (^1.6.1)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::atomist::sdm-core=7a9e0c75452b92a68d61918fb712cbc48f21bc973b4a3647725da86f880ee9d7]</code>
</details>